### PR TITLE
feat: allow transforming of manifests before writing to disk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vite-plugin-manifest-sri-with-chunk-finder",
+  "name": "vite-plugin-manifest-sri-with-transformer",
   "description": "Subresource Integrity hashes for the Vite.js manifest.",
   "version": "0.1.0",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vite-plugin-manifest-sri",
+  "name": "vite-plugin-manifest-sri-with-chunk-finder",
   "description": "Subresource Integrity hashes for the Vite.js manifest.",
   "version": "0.1.0",
   "files": [
@@ -18,13 +18,16 @@
     }
   },
   "license": "MIT",
-  "author": "Máximo Mussini <maximomussini@gmail.com>",
+  "contributors": [
+    "Máximo Mussini <maximomussini@gmail.com>",
+    "Alexander Meuer <github@alexmeuer.com>"
+  ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ElMassimo/vite-plugin-manifest-sri"
+    "url": "https://github.com/AlexMeuer/vite-plugin-manifest-sri"
   },
-  "homepage": "https://github.com/ElMassimo/vite-plugin-manifest-sri",
-  "bugs": "https://github.com/ElMassimo/vite-plugin-manifest-sri/issues",
+  "homepage": "https://github.com/AlexMeuer/vite-plugin-manifest-sri",
+  "bugs": "https://github.com/AlexMeuer/vite-plugin-manifest-sri/issues",
   "keywords": [
     "sri",
     "security",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ declare module 'vite' {
   }
 }
 
-export default function manifestSRI(options: Options = {}): Plugin {
+export default function manifestSRI (options: Options = {}): Plugin {
   const {
     algorithms = ['sha384'],
     manifestPaths = ['manifest.json', 'manifest-assets.json'],
@@ -50,13 +50,13 @@ export default function manifestSRI(options: Options = {}): Plugin {
     name: 'vite-plugin-manifest-sri',
     apply: 'build',
     enforce: 'post',
-    async writeBundle({ dir }) {
+    async writeBundle ({ dir }) {
       await Promise.all(manifestPaths.map(path => augmentManifest(path, algorithms, dir!, chunkFinder)))
     },
   }
 }
 
-async function augmentManifest(manifestPath: string, algorithms: string[], outDir: string, chunkFinder: ChunkFinder) {
+async function augmentManifest (manifestPath: string, algorithms: string[], outDir: string, chunkFinder: ChunkFinder) {
   const resolveInOutDir = (path: string) => resolve(outDir, path)
   manifestPath = resolveInOutDir(manifestPath)
 
@@ -71,11 +71,11 @@ async function augmentManifest(manifestPath: string, algorithms: string[], outDi
   }
 }
 
-function integrityForAsset(source: Buffer, algorithms: string[]) {
+function integrityForAsset (source: Buffer, algorithms: string[]) {
   return algorithms.map(algorithm => calculateIntegrityHash(source, algorithm)).join(' ')
 }
 
-export function calculateIntegrityHash(source: Buffer, algorithm: string) {
+export function calculateIntegrityHash (source: Buffer, algorithm: string) {
   const hash = createHash(algorithm).update(source).digest().toString('base64')
   return `${algorithm.toLowerCase()}-${hash}`
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
 import { createHash } from 'crypto'
 import { resolve } from 'path'
 import { promises as fs } from 'fs'
-import type { Plugin, Manifest } from 'vite'
+import type { Plugin, Manifest, ManifestChunk } from 'vite'
 
 export type Algorithm = 'sha256' | 'sha384' | 'sha512'
+
+export type ChunkFinder = (manifest: Manifest) => ManifestChunk[]
 
 export interface Options {
   /**
@@ -21,6 +23,14 @@ export interface Options {
    * @default ['manifest.json', 'manifest-assets.json']
    */
   manifestPaths?: string[]
+
+  /**
+   * A function that returns the chunks that should be augmented with the integrity hash.
+   * This can be useful if your manifest has already been transformed to a custom output format.
+   *
+   * @default (manifest) => Object.values(manifest)
+   */
+  chunkFinder?: ChunkFinder
 }
 
 declare module 'vite' {
@@ -29,23 +39,24 @@ declare module 'vite' {
   }
 }
 
-export default function manifestSRI (options: Options = {}): Plugin {
+export default function manifestSRI(options: Options = {}): Plugin {
   const {
     algorithms = ['sha384'],
     manifestPaths = ['manifest.json', 'manifest-assets.json'],
+    chunkFinder = Object.values,
   } = options
 
   return {
     name: 'vite-plugin-manifest-sri',
     apply: 'build',
     enforce: 'post',
-    async writeBundle ({ dir }) {
-      await Promise.all(manifestPaths.map(path => augmentManifest(path, algorithms, dir!)))
+    async writeBundle({ dir }) {
+      await Promise.all(manifestPaths.map(path => augmentManifest(path, algorithms, dir!, chunkFinder)))
     },
   }
 }
 
-async function augmentManifest (manifestPath: string, algorithms: string[], outDir: string) {
+async function augmentManifest(manifestPath: string, algorithms: string[], outDir: string, chunkFinder: ChunkFinder) {
   const resolveInOutDir = (path: string) => resolve(outDir, path)
   manifestPath = resolveInOutDir(manifestPath)
 
@@ -53,18 +64,18 @@ async function augmentManifest (manifestPath: string, algorithms: string[], outD
     = await fs.readFile(manifestPath, 'utf-8').then(JSON.parse, () => undefined)
 
   if (manifest) {
-    await Promise.all(Object.values(manifest).map(async (chunk) => {
+    await Promise.all(chunkFinder(manifest).map(async (chunk) => {
       chunk.integrity = integrityForAsset(await fs.readFile(resolveInOutDir(chunk.file)), algorithms)
     }))
     await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2))
   }
 }
 
-function integrityForAsset (source: Buffer, algorithms: string[]) {
+function integrityForAsset(source: Buffer, algorithms: string[]) {
   return algorithms.map(algorithm => calculateIntegrityHash(source, algorithm)).join(' ')
 }
 
-export function calculateIntegrityHash (source: Buffer, algorithm: string) {
+export function calculateIntegrityHash(source: Buffer, algorithm: string) {
   const hash = createHash(algorithm).update(source).digest().toString('base64')
   return `${algorithm.toLowerCase()}-${hash}`
 }


### PR DESCRIPTION
Adds a new optional `transformer` options that accepts the final manifest before it is written to disk, allowing clients to format it how they please.