### PR TITLE
feat: extend manifest.json to include a cssIntegrity field

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export interface Options {
 declare module 'vite' {
   interface ManifestChunk {
     integrity: string
+    cssIntegrity?: string[]
   }
 }
 
@@ -55,6 +56,10 @@ async function augmentManifest (manifestPath: string, algorithms: string[], outD
   if (manifest) {
     await Promise.all(Object.values(manifest).map(async (chunk) => {
       chunk.integrity = integrityForAsset(await fs.readFile(resolveInOutDir(chunk.file)), algorithms)
+      if (chunk.css) {
+        chunk.cssIntegrity = await Promise.all(chunk.css.map(async css =>
+          integrityForAsset(await fs.readFile(resolveInOutDir(css)), algorithms)))
+      }
     }))
     await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2))
   }

--- a/tests/__snapshots__/build.spec.ts.snap
+++ b/tests/__snapshots__/build.spec.ts.snap
@@ -18,7 +18,10 @@ exports[`build > manifest snapshot 1`] = `
     \\"file\\": \\"assets/main-dLnuJ4t2.js\\",
     \\"isEntry\\": true,
     \\"src\\": \\"entrypoints/main.ts\\",
-    \\"integrity\\": \\"sha384-vJj4PmZ9vllU99cNXZ5ozrfo6a0h/wUVLWsVtmbltVr32o549nSSXYMj8ZzenCLt\\"
+    \\"integrity\\": \\"sha384-vJj4PmZ9vllU99cNXZ5ozrfo6a0h/wUVLWsVtmbltVr32o549nSSXYMj8ZzenCLt\\",
+    \\"cssIntegrity\\": [
+      \\"sha384-bqzLq+mQSriGZYcwm8aYVPI+TilL6LHvyx/zGwJ8t3r08UKKjeIkeleDKAYTZT1J\\"
+    ]
   },
   \\"entrypoints/styles.css\\": {
     \\"file\\": \\"assets/styles-5G55TvLQ.css\\",

--- a/tests/build.spec.ts
+++ b/tests/build.spec.ts
@@ -18,6 +18,9 @@ describe('build', () => {
 
     expect(manifest['entrypoints/styles.css'].integrity)
       .toEqual('sha384-HmlJ0WJXVNLaqWQYVRhZgsW1JBN4XBjm3j+j38nagNFimvBxi8nZ1FUysAc9JJvL')
+
+    expect(manifest['entrypoints/main.ts'].cssIntegrity[0])
+      .toEqual('sha384-bqzLq+mQSriGZYcwm8aYVPI+TilL6LHvyx/zGwJ8t3r08UKKjeIkeleDKAYTZT1J')
   })
 
   test('manifest snapshot', () => {


### PR DESCRIPTION
Hi, thanks a lot for your work on this plugin!

With Vite 5, css files that are imported from js no longer get a seperate entry in the manifest. They only get an entry in the `css` array field within the entry for the js file that imports them. I propose extending manifest.json with a `cssIntegrity` field, containing the respective hashes for css imports in the same order as the imports themselves.